### PR TITLE
Update teletab regex for all house tablet options

### DIFF
--- a/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
@@ -110,7 +110,7 @@ public class SuppliesTrackerPlugin extends Plugin
 	private static final Pattern eatPattern = Pattern.compile("^eat");
 	private static final Pattern drinkPattern = Pattern.compile("^drink");
 	private static final Pattern teleportPattern = Pattern.compile("^teleport");
-	private static final Pattern teletabPattern = Pattern.compile("^break|^troll stronghold|^weiss");
+	private static final Pattern teletabPattern = Pattern.compile("^break|^troll stronghold|^weiss|^inside|^outside|^group"); // "Troll Stronghold" from Stony basalt, "Weiss" from Icy basalt, "Inside"/"Outside"/"Group" from house tablet
 	private static final Pattern spellPattern = Pattern.compile("^cast|^grand\\sexchange|^outside|^seers|^yanille");
 	private static final Pattern bpDartsPattern = Pattern.compile("Darts: <col=007f00>(.*) dart x (.*)</col>\\. Scales: <col=007f00>(.*) \\((.*)%\\)</col>\\.");
 


### PR DESCRIPTION
#33 

(This only addresses the house-related part of issue.)

I noticed that using the "Outside" house tablet option (for quickly getting to a friend's house) wasn't appearing in my used supplies. Digging in, didn't see all supported house teletab options supported. 

I confirmed both "Inside" and "Outside" don't currently generate a supplies entry. I could not confirm if "Group" also doesn't work, since I don't have a GIM.