### PR TITLE
Add JSON file saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ Crystal tools <br>
 *preview has weapon charges enabled and disabled to show both styles*
 
 ![Preview](https://i.gyazo.com/dc858c9708d3da4eb2f5fdcc73d424b5.png)
+
+
+## Ability to save as JSON
+Previous entries in normal data entry will not be added to a json file, as we do not know when they were used.
+Will save all data according to the date that they were used. This can further expand to the UI panel of the plugin to show what was just used during a certain timespan.

--- a/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
@@ -65,4 +65,14 @@ public interface SuppliesTrackerConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "jsonEnabled",
+		name = "Save data as json",
+		description = "Save data in a json format."
+	)
+	default boolean jsonEnabled()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/suppliestracker/SuppliesTrackerItemJson.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerItemJson.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018, Daddy Dozer <https://github.com/Dyldozer>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.suppliestracker;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter(AccessLevel.PUBLIC)
+@Setter(AccessLevel.PUBLIC)
+@AllArgsConstructor
+public class SuppliesTrackerItemJson
+{
+	private int id;
+	private String name;
+	private int quantity;
+	private long price;
+	private ZonedDateTime usedTime;
+
+	public String toJson()
+	{
+		Gson gson = new GsonBuilder()
+			.registerTypeAdapter(ZonedDateTime.class, new TypeAdapter<ZonedDateTime>() {
+				@Override
+				public void write(JsonWriter out, ZonedDateTime value) throws IOException {
+					out.value(value.toString());
+				}
+
+				@Override
+				public ZonedDateTime read(JsonReader in) throws IOException {
+					return ZonedDateTime.parse(in.nextString());
+				}
+			})
+			.enableComplexMapKeySerialization()
+			.setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
+			.create();
+		return gson.toJson(this);
+	}
+}

--- a/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
@@ -34,7 +34,12 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayDeque;
+import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -1273,8 +1278,18 @@ public class SuppliesTrackerPlugin extends Plugin
 	 *
 	 * @param itemId the id of the item
 	 * @param count  the amount of the item to add to the tracker
+	 * @param isFromGameStateChanged we want to intiialize the lists, but not the JSON as that will add dupes
 	 */
-	public void buildEntries(int itemId, int count)
+	public void buildEntries(int itemId, int count) { buildEntries(itemId, count, false); }
+
+	/**
+	 * Add an item to the supply tracker
+	 *
+	 * @param itemId the id of the item
+	 * @param count  the amount of the item to add to the tracker
+	 * @param isFromGameStateChanged we want to intiialize the lists, but not the JSON as that will add dupes
+	 */
+	public void buildEntries(int itemId, int count, boolean isFromGameStateChanged)
 	{
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		String name = itemComposition.getName();
@@ -1356,6 +1371,18 @@ public class SuppliesTrackerPlugin extends Plugin
 			currentSuppliesEntry.put(itemId, newEntryC);
 		}
 
+		if(config.jsonEnabled() && !isFromGameStateChanged)
+		{
+			System.out.println("Is it here that we are shoving a bunch?");
+			sessionHandler.addNewRecordToJson(new SuppliesTrackerItemJson(
+				itemId,
+				name,
+				count,
+				calculatedPrice * count,
+				ZonedDateTime.now(ZoneId.systemDefault())
+			));
+		}
+
 		SwingUtilities.invokeLater(() -> panel.addItem(showSession ? newEntryC : newEntry));
 	}
 
@@ -1368,8 +1395,18 @@ public class SuppliesTrackerPlugin extends Plugin
 	 * Add an item to the supply tracker
 	 *
 	 * @param itemId the id of the item
+	 * @param count  the amount of the item to add to the tracker
 	 */
-	private void buildChargesEntries(int itemId, int count)
+	public void buildChargesEntries(int itemId, int count) { buildEntries(itemId, count, false); }
+
+	/**
+	 * Add an item to the supply tracker
+	 *
+	 * @param itemId the id of the item
+	 * @param count the amount of the item to add to the tracker
+	 * @param isFromGameStateChanged we want to intiialize the lists, but not the JSON as that will add dupes
+	 */
+	private void buildChargesEntries(int itemId, int count, boolean isFromGameStateChanged)
 	{
 		final ItemComposition itemComposition = itemManager.getItemComposition(itemId);
 		String name = itemComposition.getName();
@@ -1467,6 +1504,18 @@ public class SuppliesTrackerPlugin extends Plugin
 		{
 			sessionHandler.addToSession(itemId, count, true);
 			currentSuppliesEntry.put(itemId, newEntryC);
+		}
+
+		if(config.jsonEnabled() && !isFromGameStateChanged)
+		{
+			System.out.println("or here?");
+			sessionHandler.addNewRecordToJson(new SuppliesTrackerItemJson(
+				itemId,
+				name,
+				count,
+				calculatedPrice * count,
+				ZonedDateTime.now(ZoneId.systemDefault())
+			));
 		}
 
 		SwingUtilities.invokeLater(() -> panel.addItem(showSession ? newEntryC : newEntry));
@@ -1723,12 +1772,12 @@ public class SuppliesTrackerPlugin extends Plugin
 
 				if (temp[0].contains("c"))
 				{
-					buildChargesEntries(Integer.parseInt(temp[0].replace("c", "")), Integer.parseInt(temp[1]));
+					buildChargesEntries(Integer.parseInt(temp[0].replace("c", "")), Integer.parseInt(temp[1]), true);
 					sessionHandler.setupMaps(Integer.parseInt(temp[0].replace("c", "")), Integer.parseInt(temp[1]), true);
 				}
 				else
 				{
-					buildEntries(Integer.parseInt(temp[0]), Integer.parseInt(temp[1]));
+					buildEntries(Integer.parseInt(temp[0]), Integer.parseInt(temp[1]), true);
 					sessionHandler.setupMaps(Integer.parseInt(temp[0]), Integer.parseInt(temp[1]), false);
 				}
 			}

--- a/src/main/java/com/suppliestracker/session/SessionHandler.java
+++ b/src/main/java/com/suppliestracker/session/SessionHandler.java
@@ -1,6 +1,13 @@
 package com.suppliestracker.session;
 
 import com.google.inject.Inject;
+import com.suppliestracker.SuppliesTrackerItemJson;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import jdk.vm.ci.meta.Local;
 import net.runelite.api.Client;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -82,6 +89,31 @@ public class SessionHandler
 			{
 				i.printStackTrace();
 			}
+
+		}
+		catch (IOException e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+	public void addNewRecordToJson(SuppliesTrackerItemJson json)
+	{
+		try
+		{
+			File jsonDir = new File(RUNELITE_DIR + "/supplies-tracker/json");
+			jsonDir.mkdir();
+
+			DateTimeFormatter timeStampPattern = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+			File sessionFile = new File(RUNELITE_DIR + "/supplies-tracker/json/" + timeStampPattern.format(java.time.LocalDateTime.now()) + ".log");
+
+			sessionFile.createNewFile();
+
+			Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sessionFile, true), "UTF-8"));
+			writer.append(json.toJson());
+			writer.append("\n");
+			writer.flush();
+			writer.close();
 
 		}
 		catch (IOException e)


### PR DESCRIPTION
Currently, the way that the files are saved it is incredibly hard to tell what supplies were used when. With a JSON file saving, we can see when exactly the supplies were used, and maybe in the future we can even add that to the UI panel of the plugin. 

For now, this PR just handles the saving into a JSON format. The other saving pieces still exist, this just adds a new way to save it. 